### PR TITLE
Fixed URL to the latest brainhack school URL.

### DIFF
--- a/.github/ISSUE_TEMPLATE/hackathon-project-form.yml
+++ b/.github/ISSUE_TEMPLATE/hackathon-project-form.yml
@@ -94,17 +94,17 @@ body:
       label: Recommended tutorials for new contributors
       description: We provided [a list of tutorials](https://ohbm.github.io/hackathon2023/traintrack/) that might be helpful for new contributors. Please check all the tutorials that will be useful to work on your project.
       options:
-        - label: "[Set up a brainhack friendly computing environment](https://school.brainhackmtl.org/modules/installation/)"
-        - label: "[A introduction to Bash](https://school.brainhackmtl.org/modules/introduction_to_terminal/)"
-        - label: "[Python: Writing a script](https://school.brainhackmtl.org/modules/python_scripts/)"
-        - label: "[Python: Data analysis with Python](https://school.brainhackmtl.org/modules/python_data_analysis/)"
-        - label: "[Python: Visualisation](https://school.brainhackmtl.org/modules/python_visualization/)"
-        - label: "[Machine learning basics](https://school.brainhackmtl.org/modules/machine_learning_basics/)"
-        - label: "[BIDS](https://school.brainhackmtl.org/modules/bids/)"
-        - label: "[Machine learning for neuroimaging](https://school.brainhackmtl.org/modules/machine_learning_neuroimaging/)"
-        - label: "[VCS: Using Git and Github](https://school.brainhackmtl.org/modules/git_github/)"
-        - label: "[VCS: Data management with Datalad](https://school.brainhackmtl.org/modules/datalad/)"
-        - label: "[Virtualization](https://school.brainhackmtl.org/modules/containers/)"
+        - label: "[Set up a brainhack friendly computing environment](https://school-brainhack.github.io/modules/installation/)"
+        - label: "[A introduction to Bash](https://school-brainhack.github.io/modules/introduction_to_terminal/)"
+        - label: "[Python: Writing a script](https://school-brainhack.github.io/modules/python_scripts/)"
+        - label: "[Python: Data analysis with Python](https://school-brainhack.github.io/modules/python_data_analysis/)"
+        - label: "[Python: Visualisation](https://school-brainhack.github.io/modules/python_visualization/)"
+        - label: "[Machine learning basics](https://school-brainhack.github.io/modules/machine_learning_basics/)"
+        - label: "[BIDS](https://school-brainhack.github.io/modules/bids/)"
+        - label: "[Machine learning for neuroimaging](https://school-brainhack.github.io/modules/machine_learning_neuroimaging/)"
+        - label: "[VCS: Using Git and Github](https://school-brainhack.github.io/modules/git_github/)"
+        - label: "[VCS: Data management with Datalad](https://school-brainhack.github.io/modules/datalad/)"
+        - label: "[Virtualization](https://school-brainhack.github.io/modules/containers/)"
         - label: "High Performance Computing: [Oracle cloud resource](https://brainhack.org/brainhack_cloud/)"
 
   - type: textarea


### PR DESCRIPTION
So it turns out I open an issue to fix the brainhack school URLs ... only to suggest another deprecated URL :roll_eyes: 

I need to do some serious spring url cleaning.

This PR fixes the URL to the actual up-to-date brainhack school website, with refreshed tutorials. 